### PR TITLE
学科ごとにtheadの背景色を変更した

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/kogaku/kikai/index.html">機械工学科</a>
                                 　教室：7.201
                             </caption>
-                            <thead>
+                            <thead class="thead_engineering">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -165,7 +165,7 @@
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/kogaku/koku/index.html">航空システム工学科</a>
                                 教室：24.112
                             </caption>
-                            <thead>
+                            <thead class="thead_engineering">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -224,7 +224,7 @@
                             <caption id="menu_er">
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/kogaku/robo/index.html">ロボティクス学科</a>教室：23.102
                             </caption>
-                            <thead>
+                            <thead class="thead_engineering">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -276,7 +276,7 @@
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/kogaku/denki/index.html">電気電子工学科</a>
                                 教室：7.202
                             </caption>
-                            <thead>
+                            <thead class="thead_engineering">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -358,7 +358,7 @@
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/kogaku/joho/index.html">情報工学科</a>
                                 教室：7.203
                             </caption>
-                            <thead>
+                            <thead class="thead_engineering">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -395,7 +395,7 @@
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/kogaku/kankyo_doboku/index.html">環境土木工学科</a>
                                 教室：7.115
                             </caption>
-                            <thead>
+                            <thead class="thead_engineering">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -440,7 +440,7 @@
                                  <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/frontier/media/index.html">メディア情報学科</a>
                                 教室：7.204
                             </caption>
-                            <thead>
+                            <thead class="thead_infomatics">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -492,7 +492,7 @@
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/frontier/keiei/index.html">経営情報学科</a>
                                 教室：7.303
                             </caption>
-                            <thead>
+                            <thead class="thead_infomatics">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -532,7 +532,7 @@
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/frontier/shinri/index.html">心理化学科　</a>
                                 教室：7.305
                             </caption>
-                            <thead>
+                            <thead class="thead_infomatics">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -573,7 +573,7 @@
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/kenchiku/kenchiku/index.html">建築学科</a>
                                 教室：23.211
                             </caption>
-                            <thead>
+                            <thead class="thead_architecture">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -613,7 +613,7 @@
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/bio_kagaku/kagaku/index.html">応用化学科　</a>
                                 教室：24.117-1
                             </caption>
-                            <thead>
+                            <thead class="thead_bio">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -650,7 +650,7 @@
                                 <a href="https://www.kanazawa-it.ac.jp/gakubu_daigakuin/bio_kagaku/bio/index.html">応用バイオ学科</a>
                                 教室：24.101
                             </caption>
-                            <thead>
+                            <thead class="thead_bio">
                                 <tr>
                                     <th>時間</th>
                                     <th>イベント</th>
@@ -702,7 +702,7 @@
 
                         <h3 id="menu_engineer">工学部</h3>
                         <table>
-                            <thead>
+                            <thead class="thead_engineering">
                                 <tr>
                                     <th>学科名</th>
                                     <td>教室場所</td>
@@ -763,7 +763,7 @@
                     <li>
                         <h3 id="menu_frontier">情報フロンティア学部</h3>
                         <table>
-                            <thead>
+                            <thead class="thead_infomatics">
                                 <tr>
                                     <th>学科名</th>
                                     <td>教室場所</td>
@@ -800,7 +800,7 @@
                     <li>
                         <h3 id="menu_architecture">建築学部</h3>
                         <table>
-                            <thead>
+                            <thead class="thead_architecture">
                                 <tr>
                                     <th>学科名</th>
                                     <td>教室場所</td>
@@ -821,7 +821,7 @@
                     <li>
                         <h3 id="menu_bio">バイオ・科学部</h3>
                         <table>
-                            <thead>
+                            <thead class="thead_bio">
                                 <tr>
                                     <th>学科名</th>
                                     <td>教室場所</td>

--- a/main_style.css
+++ b/main_style.css
@@ -13,12 +13,20 @@ body {
     */
 }
 
+.thead_engineering {
+    background-color: #84afba;
+}
 
-.section_inner table > thead tr {
-    background-color: #1D4874;  /*theme color 2*/
-    /*
-    background-color: #1aac2f; !*theme color 2*!
-    */
+.thead_infomatics {
+    background-color: #c16c70;
+}
+
+.thead_architecture {
+    background-color: #9fb386;
+}
+
+.thead_bio {
+    background-color: #6b7da8;
 }
 
 h1 .underline {


### PR DESCRIPTION
## 概要

学科ごとの違いが分かりづらいというフィードバックがあったので thead の背景色を変更した
色は[金沢工業大学の公式ページ](https://www.kanazawa-it.ac.jp/gakubu_daigakuin/index.html)を参考にした

<img width="692" alt="Screen Shot 2019-03-10 at 15 30 15" src="https://user-images.githubusercontent.com/38908416/54081540-8dab5400-4349-11e9-8236-83e6c458096b.png">

## タスク

- [x] css を修正
- [x] thead の背景色を変更

確認事項なのですが、以前からあった以下の CSS を削除したのは問題ないでしょうか

```css
.section_inner table > thead tr {
    background-color: #1D4874;  /*theme color 2*/
    /*
    background-color: #1aac2f; !*theme color 2*!
    */
}
```